### PR TITLE
Add support for array serialization

### DIFF
--- a/cartographer/src/main/java/com/segment/cartographer/Cartographer.java
+++ b/cartographer/src/main/java/com/segment/cartographer/Cartographer.java
@@ -189,6 +189,15 @@ public class Cartographer {
     writer.endArray();
   }
 
+  /** Print the json representation of an array to the given writer. */
+  private static void arrayToWriter(Object[] array, JsonWriter writer) throws IOException {
+    writer.beginArray();
+    for (Object value : array) {
+      writeValue(value, writer);
+    }
+    writer.endArray();
+  }
+
   /**
    * Writes the given {@link Object} to the {@link JsonWriter}.
    *
@@ -205,6 +214,8 @@ public class Cartographer {
       listToWriter((List) value, writer);
     } else if (value instanceof Map) {
       mapToWriter((Map) value, writer);
+    } else if (value.getClass().isArray()) {
+      arrayToWriter((Object[]) value, writer);
     } else {
       writer.value(String.valueOf(value));
     }

--- a/cartographer/src/test/java/com/segment/cartographer/CartographerTest.java
+++ b/cartographer/src/test/java/com/segment/cartographer/CartographerTest.java
@@ -146,7 +146,7 @@ public class CartographerTest {
     assertThat(map).isEqualTo(expected);
   }
 
-  @Test public void encodesArrays() throws IOException {
+  @Test public void encodesArraysWithLists() throws IOException {
     Map<String, Object> map =
         ImmutableMap.<String, Object>builder().put("a", Arrays.asList("b", "c", "d")).build();
 
@@ -159,7 +159,35 @@ public class CartographerTest {
         + "}");
   }
 
-  @Test public void decodesArrays() throws IOException {
+  @Test public void decodesArraysWithLists() throws IOException {
+    String json = "{\n" //
+        + "  \"a\": [\n" //
+        + "    \"b\",\n" //
+        + "    \"c\",\n" //
+        + "    \"d\"\n" //
+        + "  ]\n" //
+        + "}";
+
+    Map<String, Object> expected =
+        ImmutableMap.<String, Object>builder().put("a", Arrays.asList("b", "c", "d")).build();
+
+    assertThat(cartographer.fromJson(json)).isEqualTo(expected);
+  }
+
+  @Test public void encodesArraysWithArrays() throws IOException {
+    Map<String, Object> map =
+        ImmutableMap.<String, Object>builder().put("a", new String[] { "b", "c", "d" }).build();
+
+    assertThat(cartographer.toJson(map)).isEqualTo("{\n" //
+        + "  \"a\": [\n" //
+        + "    \"b\",\n" //
+        + "    \"c\",\n" //
+        + "    \"d\"\n" //
+        + "  ]\n" //
+        + "}");
+  }
+
+  @Test public void decodesArraysWithArraysAsLists() throws IOException {
     String json = "{\n" //
         + "  \"a\": [\n" //
         + "    \"b\",\n" //


### PR DESCRIPTION
Previously, this would fall through to String.valueOf(array).
The alternative is to use a List.